### PR TITLE
Fix missing router dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-spring": "^9.7.2",
     "framer-motion": "^10.16.5",
     "recharts": "^2.8.0",
-    "html2canvas": "^1.4.1"
+    "html2canvas": "^1.4.1",
+    "react-router-dom": "^6.23.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.16",


### PR DESCRIPTION
## Summary
- add `react-router-dom` to dependencies

## Testing
- `npm test` *(fails: jest not found)*