### PR TITLE
Add Tinder style card swipe UI

### DIFF
--- a/src/components/SwipeCard/SwipeCard.tsx
+++ b/src/components/SwipeCard/SwipeCard.tsx
@@ -1,22 +1,38 @@
-import { motion, useAnimation } from 'framer-motion';
+import {
+  motion,
+  useAnimation,
+  useMotionValue,
+  useTransform,
+} from 'framer-motion';
 
 interface Props {
   content: string;
   onSwipe: (direction: 'left' | 'right') => void;
+  /**
+   * 表示順位。0が最前面となる。
+   */
+  index?: number;
 }
 
-export const SwipeCard = ({ content, onSwipe }: Props): JSX.Element => {
+export const SwipeCard = ({ content, onSwipe, index = 0 }: Props): JSX.Element => {
   const controls = useAnimation();
+  const x = useMotionValue(0);
+  const rotate = useTransform(x, [-200, 200], [-20, 20]);
+  const likeOpacity = useTransform(x, [50, 150], [0, 1]);
+  const nopeOpacity = useTransform(x, [-50, -150], [0, 1]);
 
-  const handleDragEnd = (_: unknown, info: { offset: { x: number } }): void => {
-    const { x } = info.offset;
-    if (x > 100) {
-      void controls.start({ x: 300, opacity: 0 }).then(() => {
+  const handleDragEnd = (
+    _: unknown,
+    info: { offset: { x: number }; velocity: { x: number } },
+  ): void => {
+    const { x: offsetX } = info.offset;
+    if (offsetX > 100) {
+      void controls.start({ x: 500, opacity: 0 }).then(() => {
         onSwipe('right');
         controls.set({ x: 0, opacity: 1 });
       });
-    } else if (x < -100) {
-      void controls.start({ x: -300, opacity: 0 }).then(() => {
+    } else if (offsetX < -100) {
+      void controls.start({ x: -500, opacity: 0 }).then(() => {
         onSwipe('left');
         controls.set({ x: 0, opacity: 1 });
       });
@@ -30,9 +46,22 @@ export const SwipeCard = ({ content, onSwipe }: Props): JSX.Element => {
       drag="x"
       onDragEnd={handleDragEnd}
       animate={controls}
-      className="bg-white p-4 rounded shadow-md touch-pan-y select-none"
+      style={{ x, rotate, zIndex: 100 - index, scale: 1 - index * 0.05, top: index * 8 }}
+      className="absolute w-full h-full bg-white rounded-xl shadow-xl flex items-center justify-center select-none touch-pan-y"
     >
-      {content}
+      <motion.div
+        className="absolute top-5 left-5 text-green-500 font-bold text-3xl"
+        style={{ opacity: likeOpacity }}
+      >
+        YES
+      </motion.div>
+      <motion.div
+        className="absolute top-5 right-5 text-red-500 font-bold text-3xl"
+        style={{ opacity: nopeOpacity }}
+      >
+        NO
+      </motion.div>
+      <div className="px-8 text-center text-lg">{content}</div>
     </motion.div>
   );
 };

--- a/src/pages/Diagnosis.tsx
+++ b/src/pages/Diagnosis.tsx
@@ -14,17 +14,45 @@ export const Diagnosis = (): JSX.Element => {
 
   const handleSwipe = (dir: 'left' | 'right'): void => {
     const q = questions[current];
-    setAnswers([...answers, { questionId: q.id, value: dir === 'right' ? 'yes' : 'no', timestamp: Date.now() }]);
-    if (current + 1 < questions.length) setCurrent(current + 1);
-    else navigate('/results', { state: { answers: [...answers, { questionId: q.id, value: dir === 'right' ? 'yes' : 'no', timestamp: Date.now() }] } });
+    setAnswers([
+      ...answers,
+      {
+        questionId: q.id,
+        value: dir === 'right' ? 'yes' : 'no',
+        timestamp: Date.now(),
+      },
+    ]);
+    if (current + 1 < questions.length) {
+      setCurrent(current + 1);
+    } else {
+      navigate('/results', {
+        state: {
+          answers: [
+            ...answers,
+            { questionId: q.id, value: dir === 'right' ? 'yes' : 'no', timestamp: Date.now() },
+          ],
+        },
+      });
+    }
   };
 
   return (
     <DiagnosisContext.Provider value={{ answers, setAnswers }}>
       <Layout>
         <ProgressBar current={current} total={questions.length} />
-        <div className="mt-4">
-          <SwipeCard content={questions[current].content} onSwipe={handleSwipe} />
+        <div className="mt-4 relative h-80">
+          {questions
+            .slice(current, current + 3)
+            .map((q, i) => ({ q, idx: i }))
+            .reverse()
+            .map(({ q, idx }) => (
+              <SwipeCard
+                key={q.id}
+                content={q.content}
+                onSwipe={handleSwipe}
+                index={idx}
+              />
+            ))}
         </div>
       </Layout>
     </DiagnosisContext.Provider>


### PR DESCRIPTION
## Summary
- add overlay and motion effects for Tinder-like card swipe
- display a deck of up to three cards during diagnosis

## Testing
- `npm test` *(fails: jest not found)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced swipe cards with motion effects, including rotation and animated "YES"/"NO" labels that fade in based on swipe direction.
  - Introduced a stacked card interface, allowing users to see and interact with multiple swipe cards at once.

- **Style**
  - Improved visual feedback and layering for swipe cards, including dynamic scaling, z-index, and vertical offset for a more engaging experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->