### PR TITLE
Add AI generation framework

### DIFF
--- a/src/__tests__/ai.test.ts
+++ b/src/__tests__/ai.test.ts
@@ -1,0 +1,9 @@
+import { renderHook, act } from '@testing-library/react';
+import { useAIGeneration } from '../hooks/useAIGeneration';
+
+const answers = [];
+
+test('useAIGeneration initializes', () => {
+  const { result } = renderHook(() => useAIGeneration(answers));
+  expect(result.current.aiContent.detailed_analysis).toBeNull();
+});

--- a/src/components/AIContent/AIContentSection.tsx
+++ b/src/components/AIContent/AIContentSection.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { AIGeneratedContent } from '../../types/ai';
+
+interface Props {
+  title: string;
+  icon: string;
+  content: AIGeneratedContent | null;
+  isLoading: boolean;
+  onGenerate: () => void;
+}
+
+export const AIContentSection = ({ title, icon, content, isLoading, onGenerate }: Props) => {
+  const [expanded, setExpanded] = useState(true);
+
+  if (isLoading) {
+    return (
+      <div className="ai-content-section border border-gray-200 rounded-lg p-4 mb-4">
+        <div className="flex items-center mb-3">
+          <span className="text-2xl mr-2">{icon}</span>
+          <h3 className="text-lg font-semibold">{title}</h3>
+        </div>
+        <div className="text-sm text-gray-500">AIが分析中...</div>
+      </div>
+    );
+  }
+
+  if (!content) {
+    return (
+      <div className="ai-content-section border border-gray-200 rounded-lg p-4 mb-4 flex justify-between items-center">
+        <div className="flex items-center">
+          <span className="text-2xl mr-2">{icon}</span>
+          <h3 className="text-lg font-semibold">{title}</h3>
+        </div>
+        <button onClick={onGenerate} className="px-3 py-1 bg-blue-500 text-white rounded text-sm hover:bg-blue-600">
+          生成する
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="ai-content-section border border-gray-200 rounded-lg p-4 mb-4">
+      <div className="flex items-center justify-between mb-3">
+        <button onClick={() => setExpanded(!expanded)} className="flex items-center flex-1 text-left">
+          <span className="text-2xl mr-2">{icon}</span>
+          <h3 className="text-lg font-semibold">{title}</h3>
+          <span className="ml-2 text-gray-500">{expanded ? '▼' : '▶'}</span>
+        </button>
+        <button onClick={onGenerate} className="px-2 py-1 text-sm text-gray-600 hover:text-blue-600" title="再生成">
+          🔄
+        </button>
+      </div>
+      {expanded && (
+        <div className="prose prose-sm max-w-none">
+          {content.sections.map((s, i) => (
+            <div key={i} className="mb-3">
+              {s.title && <h4 className="font-medium text-gray-800 mb-1">{s.title}</h4>}
+              <div className={s.type === 'highlight' ? 'bg-blue-50 p-2 rounded' : ''}>{s.content}</div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/context/DiagnosisContext.tsx
+++ b/src/context/DiagnosisContext.tsx
@@ -1,9 +1,16 @@
 import { createContext, useContext } from 'react';
 import { Answer } from '../types';
+import { AIGeneratedContent, AIContentType } from "../types/ai";
 
 interface DiagnosisContextProps {
   answers: Answer[];
   setAnswers: (answers: Answer[]) => void;
+  aiContent: Record<AIContentType, AIGeneratedContent | null>;
+  isGeneratingAI: Record<AIContentType, boolean>;
+  aiError: string | null;
+  generateAIContent: (type: AIContentType) => Promise<void>;
+  regenerateAIContent: (type: AIContentType) => Promise<void>;
+  clearAIError: () => void;
 }
 
 export const DiagnosisContext = createContext<DiagnosisContextProps | null>(null);

--- a/src/hooks/useAIGeneration.ts
+++ b/src/hooks/useAIGeneration.ts
@@ -1,0 +1,61 @@
+import { useState, useMemo } from 'react';
+import { AIContentType, AIGeneratedContent, AIAnalysisRequest } from '../types/ai';
+import { AIService } from '../services/aiService';
+import { useContentCache } from './useContentCache';
+import { calculateScores } from '../utils/diagnostics';
+import { Answer } from '../types';
+
+export const useAIGeneration = (answers: Answer[] | null) => {
+  const [aiContent, setAIContent] = useState<Record<AIContentType, AIGeneratedContent | null>>({
+    detailed_analysis: null,
+    smart_recommendations: null,
+    company_criteria: null,
+    career_roadmap: null,
+  });
+
+  const [isGeneratingAI, setIsGeneratingAI] = useState<Record<AIContentType, boolean>>({
+    detailed_analysis: false,
+    smart_recommendations: false,
+    company_criteria: false,
+    career_roadmap: false,
+  });
+
+  const [aiError, setAIError] = useState<string | null>(null);
+  const aiService = useMemo(() => new AIService(), []);
+  const cache = useContentCache();
+
+  const result = answers ? calculateScores(answers) : null;
+
+  const generate = async (type: AIContentType) => {
+    if (!result) return;
+    if (isGeneratingAI[type]) return;
+
+    const cached = cache.get(type, result);
+    if (cached) {
+      setAIContent(prev => ({ ...prev, [type]: cached }));
+      return;
+    }
+
+    setIsGeneratingAI(prev => ({ ...prev, [type]: true }));
+    setAIError(null);
+
+    try {
+      const req: AIAnalysisRequest = {
+        scores: result.scores,
+        personalityType: result.personalityType,
+        topCategories: result.topCategories,
+        userAnswers: answers || [],
+        contentTypes: [type],
+      };
+      const content = await aiService.generateContent(req, type);
+      setAIContent(prev => ({ ...prev, [type]: content }));
+      cache.set(type, result, content);
+    } catch (err) {
+      setAIError(err instanceof Error ? err.message : 'AI Error');
+    } finally {
+      setIsGeneratingAI(prev => ({ ...prev, [type]: false }));
+    }
+  };
+
+  return { aiContent, isGeneratingAI, aiError, generate };
+};

--- a/src/hooks/useContentCache.ts
+++ b/src/hooks/useContentCache.ts
@@ -1,0 +1,25 @@
+import { AIContentType, AIGeneratedContent, DiagnosisResult } from '../types/ai';
+
+const KEY_PREFIX = 'aiContentCache';
+
+export const useContentCache = () => {
+  const buildKey = (type: AIContentType, result: DiagnosisResult) => {
+    const raw = result.personalityType + JSON.stringify(result.scores.map((s) => s.percentage));
+    // Encode using base64 safely even when raw contains multibyte characters
+    const utf8 = encodeURIComponent(raw);
+    return `${KEY_PREFIX}-${type}-${btoa(utf8)}`;
+  };
+
+  const get = (type: AIContentType, result: DiagnosisResult): AIGeneratedContent | null => {
+    const key = buildKey(type, result);
+    const raw = localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as AIGeneratedContent) : null;
+  };
+
+  const set = (type: AIContentType, result: DiagnosisResult, content: AIGeneratedContent) => {
+    const key = buildKey(type, result);
+    localStorage.setItem(key, JSON.stringify(content));
+  };
+
+  return { get, set };
+};

--- a/src/pages/Diagnosis.tsx
+++ b/src/pages/Diagnosis.tsx
@@ -44,7 +44,7 @@ export const Diagnosis = (): JSX.Element => {
 
   const question = questions[current];
   return (
-    <DiagnosisContext.Provider value={{ answers, setAnswers }}>
+    <DiagnosisContext.Provider value={{ answers, setAnswers, aiContent: { detailed_analysis: null, smart_recommendations: null, company_criteria: null, career_roadmap: null }, isGeneratingAI: { detailed_analysis: false, smart_recommendations: false, company_criteria: false, career_roadmap: false }, aiError: null, generateAIContent: async () => {}, regenerateAIContent: async () => {}, clearAIError: () => {} }}>
       <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 flex flex-col">
         <div className="px-6 py-4">
           <div className="flex items-center justify-between mb-4">

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -2,6 +2,8 @@ import { useLocation, Link } from 'react-router-dom';
 import { useState, useEffect, type SVGProps } from 'react';
 import { calculateScores } from '../utils/diagnostics';
 import { categories } from '../data/categories';
+import { useAIGeneration } from "../hooks/useAIGeneration";
+import { AIContentSection } from "../components/AIContent/AIContentSection";
 import type { Answer, DiagnosisResult } from '../types';
 import { CompanyEvaluator } from '../components/CompanyEvaluator/CompanyEvaluator';
 import {
@@ -155,6 +157,7 @@ export const Results = (): JSX.Element => {
   const [activeTab, setActiveTab] = useState<'overview' | 'recommendations' | 'company-eval'>('overview');
   const [animatedData, setAnimatedData] = useState<typeof fullData>([]);
   const [shareOpen, setShareOpen] = useState(false);
+  const { aiContent, isGeneratingAI, aiError, generate } = useAIGeneration(answers);
 
   const fullData = result.scores.map((s) => ({
     category: categories[s.category],
@@ -167,6 +170,13 @@ export const Results = (): JSX.Element => {
       setAnimatedData(fullData);
     }, 500);
     return () => clearTimeout(timer);
+  }, [answers]);
+  useEffect(() => {
+    if (answers.length > 0) {
+      setTimeout(() => generate("detailed_analysis"), 1000);
+      setTimeout(() => generate("smart_recommendations"), 2000);
+      setTimeout(() => generate("company_criteria"), 3000);
+    }
   }, [answers]);
 
   const personality = personalityDetails[result.personalityType] ?? {
@@ -298,6 +308,11 @@ export const Results = (): JSX.Element => {
       <div className="p-6">
         {activeTab === 'overview' && <OverviewTab />}
         {activeTab === 'recommendations' && <RecommendationsTab />}
+        <div className="mt-6 space-y-4">
+          <AIContentSection title="あなたの就活軸 詳細分析" icon="🔍" content={aiContent.detailed_analysis} isLoading={isGeneratingAI.detailed_analysis} onGenerate={() => generate("detailed_analysis")} />
+          <AIContentSection title="スマート推奨" icon="✨" content={aiContent.smart_recommendations} isLoading={isGeneratingAI.smart_recommendations} onGenerate={() => generate("smart_recommendations")} />
+          <AIContentSection title="企業評価基準" icon="📊" content={aiContent.company_criteria} isLoading={isGeneratingAI.company_criteria} onGenerate={() => generate("company_criteria")} />
+        </div>
         {activeTab === 'company-eval' && <CompanyEvaluator result={result} />}
       </div>
       {shareOpen && (

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -1,0 +1,97 @@
+import { AIAnalysisRequest, AIGeneratedContent, AIContentType } from '../types/ai';
+
+export class AIService {
+  private apiKey: string;
+  private baseURL: string;
+  private model: string;
+
+  constructor() {
+    this.apiKey = import.meta.env.VITE_OPENAI_API_KEY || '';
+    this.baseURL = 'https://api.openai.com/v1';
+    this.model = import.meta.env.VITE_AI_MODEL || 'gpt-4o-mini';
+  }
+
+  async generateContent(
+    request: AIAnalysisRequest,
+    contentType: AIContentType
+  ): Promise<AIGeneratedContent> {
+    const prompt = this.buildPrompt(request, contentType);
+
+    const response = await fetch(`${this.baseURL}/chat/completions`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        model: this.model,
+        messages: [
+          {
+            role: 'system',
+            content: this.getSystemPrompt(contentType),
+          },
+          {
+            role: 'user',
+            content: prompt,
+          },
+        ],
+        temperature: 0.7,
+        max_tokens: 1500,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`AI API Error: ${response.status}`);
+    }
+
+    const data = await response.json();
+    return this.formatResponse(data, contentType);
+  }
+
+  private buildPrompt(request: AIAnalysisRequest, contentType: AIContentType): string {
+    const baseData = {
+      scores: request.scores.map(s => `${s.category}: ${s.percentage}%`).join('\n'),
+      personalityType: request.personalityType,
+      topCategories: request.topCategories.join(', '),
+    };
+
+    switch (contentType) {
+      case 'detailed_analysis':
+        return `\n就活軸診断結果を詳しく分析してください。\n\n【診断結果】\n${baseData.scores}\n\n【パーソナリティタイプ】\n${baseData.personalityType}\n\n【上位カテゴリ】\n${baseData.topCategories}\n\n以下の形式で200-300字程度で分析してください：\n1. 全体的な特徴・傾向\n2. 強み・特色\n3. 注意点・バランス改善点\n4. 就活での活かし方\n\n親しみやすく、実践的なアドバイスを心がけてください。\n        `;
+      case 'smart_recommendations':
+        return `\n以下の診断結果に基づき、具体的で実践的な推奨を行ってください。\n\n【診断データ】\n${baseData.scores}\nパーソナリティ: ${baseData.personalityType}\n\n以下を含めて推奨してください：\n1. おすすめ業界（3つ、理由付き）\n2. 適性職種（3つ、具体的な職種名と理由）\n3. 企業タイプの傾向（大手/ベンチャー/中小の適性）\n4. 避けるべき環境や注意点\n\nデータに基づいて具体的で実用的な内容にしてください。\n        `;
+      case 'company_criteria':
+        return `\n診断結果を基に、企業選びの評価基準を作成してください。\n\n【価値観スコア】\n${baseData.scores}\n\n以下を含めて企業評価基準を提示してください：\n1. 最重要チェックポイント（上位3項目）\n2. 企業研究で確認すべき具体的な質問（5つ）\n3. 面接で聞くべき質問例（3つ）\n4. 内定判断の決め手となるポイント\n\n実際の就活で使いやすい形で提示してください。\n        `;
+      default:
+        throw new Error(`Unknown content type: ${contentType}`);
+    }
+  }
+
+  // Fallback system prompt
+  private getSystemPrompt(contentType: AIContentType): string {
+    return 'あなたは就活アドバイザーとしてユーザーに寄り添った回答を行います。';
+  }
+
+  private formatResponse(data: any, type: AIContentType): AIGeneratedContent {
+    const content = data.choices?.[0]?.message?.content ?? '';
+    return {
+      id: crypto.randomUUID(),
+      type,
+      content,
+      metadata: {
+        confidence: 90,
+        generatedAt: Date.now(),
+        tokensUsed: data.usage?.total_tokens ?? 0,
+        model: this.model,
+      },
+      sections: [
+        {
+          title: '',
+          content,
+          type: 'text',
+          priority: 1,
+        },
+      ],
+    };
+  }
+}

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -1,0 +1,35 @@
+import { CategoryScore, Answer } from './index';
+
+export type AIContentType =
+  | 'detailed_analysis'
+  | 'smart_recommendations'
+  | 'company_criteria'
+  | 'career_roadmap';
+
+export interface ContentSection {
+  title: string;
+  content: string;
+  type: 'text' | 'list' | 'highlight';
+  priority: number;
+}
+
+export interface AIGeneratedContent {
+  id: string;
+  type: AIContentType;
+  content: string;
+  metadata: {
+    confidence: number;
+    generatedAt: number;
+    tokensUsed: number;
+    model: string;
+  };
+  sections: ContentSection[];
+}
+
+export interface AIAnalysisRequest {
+  scores: CategoryScore[];
+  personalityType: string;
+  topCategories: string[];
+  userAnswers: Answer[];
+  contentTypes: AIContentType[];
+}


### PR DESCRIPTION
## Summary
- introduce ai type definitions
- add AI service and hooks for generation and caching
- render AI content sections on Results page
- extend Diagnosis context for AI features
- add simple hook test
- fix content cache key encoding

## Testing
- `npm test` *(fails: jest not found)*