### PR TITLE
Add API-based email sending

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ VITE_OPENAI_API_KEY=your_api_key_here
 VITE_AI_PROVIDER=openai
 VITE_AI_MODEL=gpt-4o-mini
 VITE_ENABLE_AI_FEATURES=true
+VITE_EMAIL_API_URL=https://example.com/api/send

--- a/README.md
+++ b/README.md
@@ -120,3 +120,17 @@ npm run build
 ```
 
 生成物は `dist/` フォルダに出力されます。
+
+## 環境変数
+
+開発時には `.env.local` を作成し、以下の値を設定してください。
+
+```
+VITE_OPENAI_API_KEY=your_api_key_here
+VITE_AI_PROVIDER=openai
+VITE_AI_MODEL=gpt-4o-mini
+VITE_ENABLE_AI_FEATURES=true
+VITE_EMAIL_API_URL=https://example.com/api/send
+```
+
+`VITE_EMAIL_API_URL` は登録情報を送信するメール送信APIのエンドポイントを指します。

--- a/src/components/RegistrationForm/RegistrationForm.tsx
+++ b/src/components/RegistrationForm/RegistrationForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 interface Props {
-  onSubmit: (name: string, email: string) => void;
+  onSubmit: (name: string, email: string) => Promise<void>;
 }
 
 export const RegistrationForm = ({ onSubmit }: Props): JSX.Element => {
@@ -22,10 +22,10 @@ export const RegistrationForm = ({ onSubmit }: Props): JSX.Element => {
     return Object.keys(newErrors).length === 0;
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!validate()) return;
-    onSubmit(name.trim(), email.trim());
+    await onSubmit(name.trim(), email.trim());
   };
 
   return (

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -166,8 +166,8 @@ export const Results = (): JSX.Element => {
 
   const emailService = useMemo(() => new EmailService(), []);
 
-  const handleRegister = (name: string, email: string) => {
-    emailService.sendRegistration(name, email);
+  const handleRegister = async (name: string, email: string) => {
+    await emailService.sendRegistration(name, email);
     setIsRegistered(true);
     localStorage.setItem('registered', 'true');
   };

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -1,10 +1,21 @@
 export class EmailService {
-  sendRegistration(name: string, email: string): void {
-    const subject = encodeURIComponent('JobSwipe登録情報');
-    const body = encodeURIComponent(`名前: ${name}\nメール: ${email}`);
-    const mailto = `mailto:k-wada@ielove-group.jp?subject=${subject}&body=${body}`;
-    if (typeof window !== 'undefined') {
-      window.location.href = mailto;
+  private endpoint: string;
+
+  constructor() {
+    this.endpoint = import.meta.env.VITE_EMAIL_API_URL || '/api/email';
+  }
+
+  async sendRegistration(name: string, email: string): Promise<void> {
+    const response = await fetch(this.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name, email }),
+    });
+
+    if (!response.ok) {
+      throw new Error(`Failed to send email: ${response.status}`);
     }
   }
 }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_OPENAI_API_KEY: string;
   readonly VITE_AI_MODEL: string;
+  readonly VITE_EMAIL_API_URL: string;
   // 他の環境変数がある場合、ここに追加
 }
 


### PR DESCRIPTION
## Summary
- implement POST-based registration mail sender
- adjust registration form to handle async submission
- update results page to await mail sending
- expose `VITE_EMAIL_API_URL` env var and document it

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing dependencies)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Registration now sends user information to a backend email API instead of opening the user's email client.
- **Documentation**
	- Updated the README with instructions for required environment variables, including the new email API URL.
- **Chores**
	- Added a new environment variable for the email API endpoint in configuration files.
- **Refactor**
	- Improved registration flow to handle asynchronous email sending and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->