### PR TITLE
Prevent mobile zoom and back swipe

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="ja">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
     <title>JobSwipe</title>
   </head>
   <body>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,10 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Prevent pinch-zoom and browser back swipe on mobile */
+html,
+body {
+  overscroll-behavior: none;
+  touch-action: manipulation;
+}


### PR DESCRIPTION
## Summary
- set viewport to disable zoom scaling
- block overscroll and double-tap zoom in global CSS

## Testing
- `npm test` *(fails: jest not found)*